### PR TITLE
Add batchTimeoutSecs config option for sample creation script

### DIFF
--- a/sample/scripts/createSampleConfig.js
+++ b/sample/scripts/createSampleConfig.js
@@ -39,6 +39,9 @@ dynamoConfig = {
 		batchSize : {
 			N : "2"
 		},
+		batchTimeoutSecs : {
+			N : "60"
+		},
 		connectUser : {
 			S : "test_lambda_load_user"
 		},


### PR DESCRIPTION
Resolves https://github.com/awslabs/aws-lambda-redshift-loader/issues/2

@rmahfoud not sure what the default timeout should be, but made it 60...
