### PR TITLE
Ensure the "format" keyword precedes the data format

### DIFF
--- a/index.js
+++ b/index.js
@@ -761,6 +761,7 @@ exports.handler = function(event, context) {
 						}
 
 						// add data formatting directives to copy options
+						copyOptions = copyOptions + ' format '
 						if (config.dataFormat.S === 'CSV') {
 							copyOptions = copyOptions + ' csv delimiter \'' + config.csvDelimiter.S + '\'\n';
 						} else if (config.dataFormat.S === 'JSON' || config.dataFormat.S === 'AVRO') {


### PR DESCRIPTION
It seems that Redshift throws a syntax error if you provide AVRO as the data format in a COPY command if not preceded by the FORMAT keyword.

This fails:

```
copy customer
from 's3://mybucket/my.manifest'
credentials 'aws_access_key_id=<access-key-id>;aws_secret_access_key=<secret-access-key>'
manifest
avro 'auto';
```

This works:

```
copy customer
from 's3://mybucket/my.manifest'
credentials 'aws_access_key_id=<access-key-id>;aws_secret_access_key=<secret-access-key>'
manifest
format avro 'auto';
```

Note that this problem does not seem to affect CSV and JSON formats which can be specified without the "FORMAT" keyword.

This commit simply prepends the format specifier with the "FORMAT" keyword to ensure all formats can be loaded.
