### PR TITLE
Fix JSON Paths directions in setup.js

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -226,7 +226,7 @@ q_csvDelimiter = function(callback) {
 
 q_jsonPaths = function(callback) {
 	if (dynamoConfig.Item.dataFormat.S === 'JSON' || dynamoConfig.Item.dataFormat.S === 'AVRO') {
-		rl.question('Enter the JSON Paths File Location on S3 (or NULL for Auto) > ', function(answer) {
+		rl.question('Enter the JSON Paths File Location on S3 (or 'auto' instead of JSON Paths File) > ', function(answer) {
 			if (common.blank(answer) !== null) {
 				dynamoConfig.Item.jsonPath = {
 					S : answer


### PR DESCRIPTION
Currently the setup directions read: "Enter the JSON Paths File Location on S3 (or NULL for Auto) >". 
If I enter "NULL" for the JSON Copy 'auto' option, the redshift query incorrectly uses "manifest JSON 'NULL'" instead of the expected "manifest JSON 'auto'". I've corrected the directions so users know to enter 'auto' instead of 'NULL' to use the JSON Copy 'auto' option.
