### PR TITLE
Add missing aws-sdk dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dependencies": {
         "async": "1.5.2",
         "node-uuid": "1.4.7",
-        "pg":"4.4.3"
+        "pg":"4.4.3",
+        "aws-sdk":"2.3.3"
     },
     "keywords": [
         "amazon",


### PR DESCRIPTION
Would it not make sense to add this? Without adding the `aws-sdk`, the setup.js cannot be run, among other things.
