### PR TITLE
fix callback argument must be a function in setTimeout()

### DIFF
--- a/common.js
+++ b/common.js
@@ -215,7 +215,7 @@ exports.writeConfig = function(setRegion, dynamoDB, dynamoConfig, outerCallback)
 			if (err) {
 				if (err.code === 'ResourceInUseException' || err.code === 'ResourceNotFoundException') {
 					// retry if the table is in use after 1 second
-					setTimeout(callback(), 1000);
+					setTimeout(callback, 1000);
 				} else {
 					// some other error - fail
 					console.log(JSON.stringify(dynamoConfig));


### PR DESCRIPTION
When running `node setup.js` I was getting the following TypeError from the following code in common.js

```
        dynamoDB.putItem(dynamoConfig, function(err, data) {
            if (err) {
                if (err.code === 'ResourceInUseException' || err.code === 'ResourceNotFoundException') {
                    // retry if the table is in use after 1 second
                    setTimeout(callback(), 1000);
                } else {
```

Here is the error message. 

```
Creating Tables in Dynamo DB if Required
/Users/jakemadden/workspace/aws/aws-lambda-redshift-loader-jm/node_modules/aws-sdk/lib/request.js:31
            throw err;
            ^

TypeError: "callback" argument must be a function
    at exports.setTimeout (timers.js:314:11)
    at Response.<anonymous> (/Users/jakemadden/workspace/aws/aws-lambda-redshift-loader-jm/common.js:218:6)
    at Request.<anonymous> (/Users/jakemadden/workspace/aws/aws-lambda-redshift-loader-jm/node_modules/aws-sdk/lib/request.js:355:18)
    at Request.callListeners (/Users/jakemadden/workspace/aws/aws-lambda-redshift-loader-jm/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/Users/jakemadden/workspace/aws/aws-lambda-redshift-loader-jm/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/Users/jakemadden/workspace/aws/aws-lambda-redshift-loader-jm/node_modules/aws-sdk/lib/request.js:615:14)
    at Request.transition (/Users/jakemadden/workspace/aws/aws-lambda-redshift-loader-jm/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/jakemadden/workspace/aws/aws-lambda-redshift-loader-jm/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /Users/jakemadden/workspace/aws/aws-lambda-redshift-loader-jm/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/Users/jakemadden/workspace/aws/aws-lambda-redshift-loader-jm/node_modules/aws-sdk/lib/request.js:38:9)
```

`setTimeout()` expects a function and therefore callback() is not a valid parameter. This PR passes the callback function itself to resolve the issue. 
