### PR TITLE
Patch setup-file batchSizeBytes

### DIFF
--- a/config.json
+++ b/config.json
@@ -21,6 +21,7 @@
 	"successTopic": "",
 	"failureTopic": "",
 	"batchSize": "3",
+	"batchSizeBytes": "",
 	"batchTimeoutSecs": "120",
 	"copyOptions": "",
 	"symmetricKey": ""

--- a/config.json.commented
+++ b/config.json.commented
@@ -91,6 +91,9 @@
   // number of CPU's in your cluster. You should set the multiple such that this count
   // causes loads to be every 2-5 minutes.
   "batchSize": "",
+  // Batches can be buffered up to a specified size. How large should a batch
+  // be before processing (bytes)?
+  "batchSizeBytes": "",
   // How old should we allow a Batch to be before loading (seconds)?  N
   // AWS Lambda will attempt to sweep out 'old' batches using this value as the number
   // of seconds old a batch can be before loading. This 'sweep' is on every S3 event on

--- a/setup-file.js
+++ b/setup-file.js
@@ -346,14 +346,14 @@ q_batchSize = function(callback) {
 };
 
 q_batchBytes = function(callback) {
-	rl.question('Batches can be buffered up to a specified size. How large should a batch be before processing (bytes)? > ', function(answer) {
-		if (common.blank(answer) !== null) {
-			dynamoConfig.Item.batchSizeBytes = {
-				N : '' + common.getIntValue(answer, rl)
-			};
-		}
-		callback(null);
-	});
+  // Batches can be buffered up to a specified size. How large should a batch
+  // be before processing (bytes)?
+  if (common.blank(setupConfig.batchSizeBytes) !== null) {
+    dynamoConfig.Item.batchSizeBytes = {
+      N : '' + common.getIntValue(setupConfig.batchSizeBytes, rl)
+    };
+  }
+  callback(null);
 };
 
 q_batchTimeoutSecs = function(callback) {


### PR DESCRIPTION
In https://github.com/awslabs/aws-lambda-redshift-loader/commit/d0188cbb9a44d5321a81a9268bee6d9045e20e87, setup-file.js included changes that attempt to read the configuration value from the command line but since rl (readline.createInterface) is not used for file-based configuration the setup fails when reaching  batchSizeBytes. This PR is a patch to allow configuration of batchSizeBytes from file using setup-file.js for release 2.4.2. 
