### PR TITLE
Add proxy support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Table of Contents
     * [Getting Started - Granting AWS Lambda rights to access your Redshift cluster](#getting-started---granting-aws-lambda-rights-to-access-your-redshift-cluster)
       * [Redshift running in VPC](#redshift-running-in-vpc)
       * [Redshift running in EC2 Classic/Not in VPC](#redshift-running-in-ec2-classicnot-in-vpc)
+      * [If you want to use http proxy instead of NAT gateway](#if-you-want-to-use-http-proxy-instead-of-nat-gateway)
     * [Getting Started - Support for Notifications &amp; Complex Workflows](#getting-started---support-for-notifications--complex-workflows)
     * [Getting Started - Entering the Configuration](#getting-started---entering-the-configuration)
     * [The Configuration S3 Prefix](#the-configuration-s3-prefix)
@@ -203,6 +204,14 @@ We recommend granting Amazon Redshift users only INSERT rights on tables to be
 loaded. Create a user with a complex password using the CREATE USER command
 (http://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_USER.html), and grant
 INSERT using GRANT (http://docs.aws.amazon.com/redshift/latest/dg/r_GRANT.html).
+
+### If you want to use http proxy instead of NAT gateway
+
+To configure environment variable of your Lambda function:
+
+1. Add a variable. Key is "https_proxy".
+2. Fill a variable. For example, http://proxy.example.org:3128
+
 
 ## Getting Started - Support for Notifications & Complex Workflows
 This function can send notifications on completion of batch processing. Using SNS,

--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,6 @@ rm dist/AWSLambdaRedshiftLoader-$ver.zip
 
 npm install --upgrade
 
-zip -r AWSLambdaRedshiftLoader-$ver.zip index.js common.js createS3TriggerFile.js constants.js kmsCrypto.js upgrades.js *.txt package.json node_modules/async node_modules/uuid node_modules/pg
+zip -r AWSLambdaRedshiftLoader-$ver.zip index.js common.js createS3TriggerFile.js constants.js kmsCrypto.js upgrades.js *.txt package.json node_modules/async node_modules/uuid node_modules/pg node_modules/https-proxy-agent
 
 mv AWSLambdaRedshiftLoader-$ver.zip dist

--- a/index.js
+++ b/index.js
@@ -20,6 +20,15 @@ var aws = require('aws-sdk');
 aws.config.update({
     region : region
 });
+var https_proxy = process.env['https_proxy'];
+if (https_proxy !== undefined && https_proxy !== "") {
+    console.log("Using proxy server " + https_proxy);
+    var proxy_agent = require('https-proxy-agent');
+    aws.config.update({
+        httpOptions: { agent: new proxy_agent(https_proxy) }
+    });
+}
+
 var s3 = new aws.S3({
     apiVersion : '2006-03-01',
     region : region

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "uuid": "3.0.1",
         "pg":"6.1.5",
         "aws-sdk":"2.49.0",
-        "minimist":"1.2.0"
+        "minimist":"1.2.0",
+        "https-proxy-agent": "1.0.0"
     },
     "keywords": [
         "amazon",


### PR DESCRIPTION
This PR is for connect with through HTTP proxy in VPC without NAT gateway.

I’m not using NAT gateway in my VPC, but using HTTP proxy.
It's have EC2 each AZ with ELB.

I'd like to connect DynamoDB with through HTTP proxy.


