### PR TITLE
Fix setup call in setup-file

### DIFF
--- a/setup-file.js
+++ b/setup-file.js
@@ -18,6 +18,8 @@ var common = require('./common');
 var async = require('async');
 var uuid = require('node-uuid');
 var dynamoDB;
+var s3;
+var lambda;
 var kmsCrypto = require('./kmsCrypto');
 var setRegion;
 
@@ -64,6 +66,13 @@ q_region = function(callback) {
 	    region : setRegion
 	});
 	kmsCrypto.setRegion(setRegion);
+    s3 = new aws.S3({
+        apiVersion: '2006-03-01'
+    });
+    lambda = new aws.Lambda({
+        apiVersion: '2015-03-31',
+        region: setRegion
+    });
 
 	callback(null);
     } else {
@@ -385,8 +394,7 @@ setup = function(overrideConfig, callback) {
     } else {
 	useConfig = dynamoConfig;
     }
-    var configWriter = common.writeConfig(setRegion, dynamoDB, useConfig, callback);
-    common.createTables(dynamoDB, configWriter);
+    common.setup(useConfig, dynamoDB, s3, lambda, callback);
 };
 // export the setup module so that customers can programmatically add new
 // configurations


### PR DESCRIPTION
When I run `node setup-file.js`, it cannot find the `common.writeConfig()`. It seemed to be missing when you modified `setup.js`. I have not seen the entire code in detail, so I'm not sure this is what you intented, but it just works for me. Please check it over.
