### PR TITLE
Remove wildcard from event prefix

### DIFF
--- a/common.js
+++ b/common.js
@@ -513,7 +513,7 @@ exports.createS3EventSource = function (s3, lambda, bucket, prefix, functionName
                                             Key: {
                                                 FilterRules: [{
                                                     Name: 'prefix',
-                                                    Value: prefix + "/*"
+                                                    Value: prefix + "/"
                                                 }]
                                             }
                                         },


### PR DESCRIPTION
Removes the the wildcard from the wildcard from the event source prefix:

\<prefix\>/* -> \<prefix\>/

Fixed the issue with the lambda not getting triggered as described in issue https://github.com/awslabs/aws-lambda-redshift-loader/issues/131