### PR TITLE
added suffix support

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -11,6 +11,7 @@
 batchId = 'batchId';
 currentBatch = 'currentBatch';
 s3prefix = 's3Prefix';
+s3suffix = 's3Suffix';
 lastUpdate = 'lastUpdate';
 complete = 'complete';
 locked = 'locked';

--- a/setup-file.js
+++ b/setup-file.js
@@ -107,6 +107,9 @@ q_filenameFilter = function (callback) {
         dynamoConfig.Item.filenameFilterRegex = {
             S: setupConfig.filenameFilter
         };
+		dynamoConfig.Item.s3Suffix = {
+            S: setupConfig.filenameFilter
+        };
     }
     callback(null);
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I've included support for using filenameFilter parameter as suffix for S3 notification. This allows to have more than one Lambda trigger with same prefix. It also reduces unnecesary function calls.
This was made to support an specific use case, I know there's work to do to make it work generally but I'm not a great js developer. If you can point me what's missing I can try to round it up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
