### PR TITLE
suffix support and load cluster failure message

### DIFF
--- a/common.js
+++ b/common.js
@@ -87,14 +87,25 @@ exports.createTables = function (dynamoDB, callback) {
         }
     };
     var configKey = s3prefix;
+
+    var sortKey = s3suffix;
+	
     var configSpec = {
         AttributeDefinitions: [{
             AttributeName: configKey,
+            AttributeType: 'S'
+        },
+		{
+            AttributeName: sortKey,
             AttributeType: 'S'
         }],
         KeySchema: [{
             AttributeName: configKey,
             KeyType: 'HASH'
+        },
+		{
+            AttributeName: sortKey,
+            KeyType: 'RANGE'
         }],
         TableName: configTable,
         ProvisionedThroughput: {
@@ -477,7 +488,7 @@ exports.ensureS3InvokePermisssions = function (lambda, bucket, prefix, functionN
     });
 };
 
-exports.createS3EventSource = function (s3, lambda, bucket, prefix, functionName, callback) {
+exports.createS3EventSource = function (s3, lambda, bucket, prefix, suffix, functionName, callback) {
     console.log("Creating S3 Event Source for s3://" + bucket + "/" + prefix);
 
     // lookup the deployed function name to get the ARN
@@ -520,6 +531,10 @@ exports.createS3EventSource = function (s3, lambda, bucket, prefix, functionName
                                                 FilterRules: [{
                                                     Name: 'prefix',
                                                     Value: prefix + "/"
+                                                },
+                                                {
+                                                    Name: 'suffix',
+                                                    Value: suffix
                                                 }]
                                             }
                                         },
@@ -584,12 +599,14 @@ exports.setup = function (useConfig, dynamoDB, s3, lambda, callback) {
     // and prefix
     var createEventSource = function (c) {
         var s3prefix = useConfig.Item.s3Prefix.S;
+        var s3suffix = useConfig.Item.s3Suffix.S;
         var tokens = s3prefix.split("/");
         var bucket = tokens[0];
         var prefix = tokens.slice(1).join("/");
+        var suffix = s3suffix;
 
         // deployedFunctionName is defined in constants.js
-        exports.createS3EventSource(s3, lambda, bucket, prefix, deployedFunctionName, function (err, configId) {
+        exports.createS3EventSource(s3, lambda, bucket, prefix, suffix, deployedFunctionName, function (err, configId) {
             c(err);
         });
     };

--- a/constants.js
+++ b/constants.js
@@ -11,6 +11,7 @@
 batchId = 'batchId';
 currentBatch = 'currentBatch';
 s3prefix = 's3Prefix';
+s3suffix = 's3Suffix';
 lastUpdate = 'lastUpdate';
 complete = 'complete';
 locked = 'locked';

--- a/setup-file.js
+++ b/setup-file.js
@@ -107,6 +107,9 @@ q_filenameFilter = function (callback) {
         dynamoConfig.Item.filenameFilterRegex = {
             S: setupConfig.filenameFilter
         };
+		dynamoConfig.Item.s3Suffix = {
+            S: setupConfig.filenameFilter
+        };
     }
     callback(null);
 };

--- a/setup.js
+++ b/setup.js
@@ -105,6 +105,9 @@ q_filenameFilter = function (callback) {
             dynamoConfig.Item.filenameFilterRegex = {
                 S: answer
             };
+            dynamoConfig.Item.s3Suffix = {
+                S: answer
+            };
         }
         callback(null);
     });


### PR DESCRIPTION
*Description of changes:*
I've included support for using filenameFilter parameter as suffix for S3 notification. This allows to have more than one Lambda trigger with same prefix. It also reduces unnecesary function calls.
This was made to support an specific use case, I know there's work to do to make it work generally but I'm not that into js. If you can point me what's missing I can try to round it up.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
