### PR TITLE
fixed  function - had a copy/paste error from setup.js

### DIFF
--- a/setup-file.js
+++ b/setup-file.js
@@ -227,7 +227,7 @@ q_postsql = function (callback) {
 
 q_df = function (callback) {
     // the Data Format (CSV, JSON, AVRO, Parquet, ORC)
-    common.validateArrayContains(['CSV', 'JSON', 'AVRO', 'Parquet', 'ORC'], answer.toUpperCase(), rl);
+    common.validateArrayContains(['CSV', 'JSON', 'AVRO', 'Parquet', 'ORC'], setupConfig.df.toUpperCase(), rl);
     dynamoConfig.Item.dataFormat = {
         S: setupConfig.df.toUpperCase()
     };


### PR DESCRIPTION
*Issue #, if available:*
Issue 195: https://github.com/awslabs/aws-lambda-redshift-loader/issues/195

When running `node setup-file.js ../configs/config-file.json` I always receive the following error:
`ReferenceError: answer is not defined`

The full error output is:
```
/Users/scottburkhalter/projects/redshift-loader/aws-lambda-redshift-loader/node_modules/aws-sdk/lib/request.js:31
            throw err;
                  ^
ReferenceError: answer is not defined
    at q_df (/Users/scottburkhalter/projects/redshift-loader/aws-lambda-redshift-loader/setup-file.js:230:77)
    at nextTask (/Users/scottburkhalter/projects/redshift-loader/aws-lambda-redshift-loader/node_modules/async/dist/async.js:5324:14)
    at next (/Users/scottburkhalter/projects/redshift-loader/aws-lambda-redshift-loader/node_modules/async/dist/async.js:5331:9)
    at /Users/scottburkhalter/projects/redshift-loader/aws-lambda-redshift-loader/node_modules/async/dist/async.js:969:16
    at /Users/scottburkhalter/projects/redshift-loader/aws-lambda-redshift-loader/setup-file.js:170:13
    at Response.<anonymous> (/Users/scottburkhalter/projects/redshift-loader/aws-lambda-redshift-loader/kmsCrypto.js:131:14)
    at Request.<anonymous> (/Users/scottburkhalter/projects/redshift-loader/aws-lambda-redshift-loader/node_modules/aws-sdk/lib/request.js:364:18)
    at Request.callListeners (/Users/scottburkhalter/projects/redshift-loader/aws-lambda-redshift-loader/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
    at Request.emit (/Users/scottburkhalter/projects/redshift-loader/aws-lambda-redshift-loader/node_modules/aws-sdk/lib/sequential_executor.js:78:10)
    at Request.emit (/Users/scottburkhalter/projects/redshift-loader/aws-lambda-redshift-loader/node_modules/aws-sdk/lib/request.js:683:14)
exit status 1
```


*Description of changes:*

The error is in the setup-file.js `q_df` function, and the variable `answer` is definitely undefined. 
https://github.com/awslabs/aws-lambda-redshift-loader/blob/master/setup-file.js#L230

Looking at the codebase, I see the same function `q_df` defined correctly in the `setup.js` script.
https://github.com/awslabs/aws-lambda-redshift-loader/blob/master/setup.js#L213

By examining the implementation in setup.js, I made an uneducated guess that the fix is to update line 230 to reference the `setupConfig.df` property which is utilized on line 232, replacing the invalid `answer` variable reference.

After making this change I was able to upload my modified configuration successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
