### PR TITLE
Fix typo in KMS alias name

### DIFF
--- a/kmsCrypto.js
+++ b/kmsCrypto.js
@@ -18,7 +18,7 @@ var authContext = {
 };
 
 // module key alias to be used for this application
-var moduleKeyName = "alias/LambaRedshiftLoaderKey";
+var moduleKeyName = "alias/LambdaRedshiftLoaderKey";
 
 var setRegion = function(region) {
     if (!region) {


### PR DESCRIPTION
*Description of changes:*
There was a small typo in the KMS alias name that either causes the initialization process to fail or to create an alias with the wrong name, depending on permissions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
