### PR TITLE
process s3 event messages from SQS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1589,7 +1589,7 @@ function handler(event, context) {
             // filter out unsupported events
             logger.error("Event type unsupported by Lambda Redshift Loader");
             logger.info(JSON.stringify(event));
-            context.done(null, null);
+            return;
         }
 
         //obtain the first record in order to establish the eventSource

--- a/index.js
+++ b/index.js
@@ -1493,7 +1493,9 @@ function handler(event, context) {
     exports.processS3EventRecord = function (event) {
         logger.info("processS3EventRecord " + JSON.stringify(event));
 
-        if (event.Records.length > 1) {
+        if (!event.Records) {
+            logger.error("The provided s3 event was not wellformed or was generated as a test event, this will be ignored.");
+        } else if (event.Records.length > 1) {
             context.done(error, "Unable to process multi-record events");
         } else {
             var r = event.Records[0];


### PR DESCRIPTION
Added ability to consume s3 event messages from an SQS queue. This
facilitates the option of having multiple consumers of s3event
notifications for the same prefix. You could for example subscribe an
SNS topic to the s3event for a given prefix and then have multiple sqs
queues subscribed to that topic. This expands usage options for
multiple varying consumers of the same s3 prefix event.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
