### PR TITLE
Fixed an Parquet check and consistency

### DIFF
--- a/index.js
+++ b/index.js
@@ -840,7 +840,10 @@ function handler(event, context) {
 
             manifestContents.entries.push({
                 url: u,
-                mandatory: true
+                mandatory: true,
+                meta: {
+                    content_length: s3Info.size
+                }
             });
         }
 
@@ -1170,7 +1173,7 @@ function handler(event, context) {
                     } else {
                         copyOptions = copyOptions + ' \'auto\' \n';
                     }
-                } else if (config.dataFormat.S === 'Parquet' || config.dataFormat.S === 'ORC') {
+                } else if (config.dataFormat.S === 'PARQUET' || config.dataFormat.S === 'ORC') {
                     copyOptions = copyOptions + ' format as ' + config.dataFormat.S;
                 } else {
                     callback(null, {

--- a/setup.js
+++ b/setup.js
@@ -210,8 +210,8 @@ q_truncateTable = function (callback) {
 };
 
 q_df = function (callback) {
-    rl.question('Enter the Data Format (CSV, JSON, AVRO, Parquet, and ORC) > ', function (answer) {
-        common.validateArrayContains(['CSV', 'JSON', 'AVRO', 'Parquet', 'ORC'], answer.toUpperCase(), rl);
+    rl.question('Enter the Data Format (CSV, JSON, AVRO, PARQUET, and ORC) > ', function (answer) {
+        common.validateArrayContains(['CSV', 'JSON', 'AVRO', 'PARQUET', 'ORC'], answer.toUpperCase(), rl);
         dynamoConfig.Item.dataFormat = {
             S: answer.toUpperCase()
         };


### PR DESCRIPTION
*Description of changes:*

Generating a configuration failed for Parquet as it was expecting all uppercase, changed it everywhere to match the rest of the data formats as well.

Fixed an issue when copying the manifest that contained parquet files because Redshift was expecting the meta property `content_length` 

Here are the cloudwatch logs I was getting:

```
  | 2020-11-15T17:38:14.824+01:00 | COPY my_test_table from 's3://lambda-redshift-loader-test/files/manifest-2020-11-15 16:38:14-6082' with credentials as 'aws_access_key_id=meyaccesskey;aws_secret_access_key=mykey' manifest format as PARQUET;
-- | -- | --
  | 2020-11-15T17:38:14.824+01:00 | commit;
  | 2020-11-15T17:38:16.200+01:00 | error:
  | 2020-11-15T17:38:16.200+01:00 | -----------------------------------------------
  | 2020-11-15T17:38:16.200+01:00 | error: File entry does not have 'meta' key.
  | 2020-11-15T17:38:16.200+01:00 | code: 15003
  | 2020-11-15T17:38:16.200+01:00 | context:
  | 2020-11-15T17:38:16.200+01:00 | query: 90820823
  | 2020-11-15T17:38:16.200+01:00 | location: spectrum_manifest.cpp:204
  | 2020-11-15T17:38:16.200+01:00 | process: padbmaster [pid=17049]
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.