### PR TITLE
Various fixes

### DIFF
--- a/common.js
+++ b/common.js
@@ -805,7 +805,7 @@ function updateConfig(s3Prefix, configAttribute, configValue, dynamoDB, callback
 
 exports.updateConfig = updateConfig;
 
-function deleteFile(dynamoDB, region, file, callback) {
+function deleteFile(dynamoDB, file, callback) {
     var fileItem = {
         Key: {
             loadFile: {

--- a/fileProcessingUtils.js
+++ b/fileProcessingUtils.js
@@ -20,8 +20,8 @@ function connect(setRegion, callback) {
 
 /** function to delete a file */
 function deleteFile(setRegion, file, callback) {
-	connect(setRegion, function(dynamoDB, s3) {
-		common.deleteFile(dynamoDB, s3, setRegion, file, callback);
+	connect(setRegion, function(dynamoDB) {
+		common.deleteFile(dynamoDB, file, callback);
 	});
 }
 

--- a/index.js
+++ b/index.js
@@ -484,7 +484,7 @@ function handler(event, context) {
                                 + thisBatchId
                                 + " which may be stuck in '"
                                 + locked
-                                + "' state. If so, unlock the back using `node unlockBatch.js <region> <batch ID> <s3Prefix>`, delete the processed file marker with `node processedFiles.js --delete --file <filename> --region <region>`, and then re-store the file in S3";
+                                + "' state. If so, unlock the batch using `node unlockBatch.js <region> <batch ID> <s3Prefix>`, delete the processed file marker with `node processedFiles.js --delete --file <filename> --region <region>`, and then re-store the file in S3";
                             logger.error(e);
 
                             var msg = "Lambda Redshift Loader unable to write to Open Pending Batch";

--- a/index.js
+++ b/index.js
@@ -484,7 +484,7 @@ function handler(event, context) {
                                 + thisBatchId
                                 + " which may be stuck in '"
                                 + locked
-                                + "' state. If so, unlock the back using `node unlockBatch.js <batch ID>`, delete the processed file marker with `node processedFiles.js -d <filename>`, and then re-store the file in S3";
+                                + "' state. If so, unlock the back using `node unlockBatch.js <region> <batch ID> <s3Prefix>`, delete the processed file marker with `node processedFiles.js --delete --file <filename> --region <region>`, and then re-store the file in S3";
                             logger.error(e);
 
                             var msg = "Lambda Redshift Loader unable to write to Open Pending Batch";


### PR DESCRIPTION
- In `fileProcessingUtils.js`, `common.deleteFile` is called with the following 5 parameters: `common.deleteFile(dynamoDB, s3, setRegion, file, callback);`. However, `deleteFile` in `common.js` is defined with the following 4 parameters `deleteFile(dynamoDB, region, file, callback)`. This is a bug and leads to an error when calling `node processedFiles.js --delete ...`.
    - Neither `s3` or `region` is used in the `deleteFile` so I removed that attribute from both the `common.js` and `fileProcessingUtils.js` files. Now, the same 3 attributes are defined/called in `common.js` and `fileProcessingUtils.js`: `dynamoDB`, `file`, and `callback`.
- Fix typo in error message and syntax of commands in `index.js` to match syntax defined in `unlockBatch.js` and `processedFiles.js`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
